### PR TITLE
ローダーズレ修正

### DIFF
--- a/html/my-assets/resources/js/display-loading-animation.js
+++ b/html/my-assets/resources/js/display-loading-animation.js
@@ -1,16 +1,15 @@
-window.addEventListener("load", animationStartStop);
+window.addEventListener("DOMContentLoaded", animationStartStop);
 
 // 画面ローディングアニメーション
 // ローディング時に表示、ローディング終了時に非表示または2秒後に非表示
 function animationStartStop(e) {
-  e.preventDefault();
-  const body = document.body;
-  const loaderWrap = document.getElementById('loader');
-  loaderWrap.classList.remove('hidden');
-  body.classList.add('overflow-hidden');
+    e.preventDefault();
+    const body = document.body;
+    const loaderWrap = document.getElementById("loader");
+    body.classList.add("overflow-hidden");
 
-  setTimeout(() => {
-    loaderWrap.classList.add('hidden');
-    body.classList.remove("overflow-hidden");
-  }, 2000);
+    setTimeout(() => {
+        loaderWrap.classList.add("hidden");
+        body.classList.remove("overflow-hidden");
+    }, 2000);
 }

--- a/html/my-assets/resources/scss/app.scss
+++ b/html/my-assets/resources/scss/app.scss
@@ -71,13 +71,14 @@ $breakpoints: (
     width: 100%;
     height: 100%;
     background-color: #fff;
-    opacity: 90%;
     z-index: 9999;
     overflow: hidden;
     .loader {
-        color: #1c4c5b;
+        color: #60A5FA;
         position: relative;
         z-index: 10000;
+        min-width: 75px;
+        min-height: 75px;
         div {
             z-index: 10000;
             position: absolute;

--- a/html/my-assets/resources/views/components/loading-animation.blade.php
+++ b/html/my-assets/resources/views/components/loading-animation.blade.php
@@ -1,5 +1,5 @@
-<div id="loader" class="loader-wrap hidden dark:bg-dark_table">
-    <div class="loader dark:text-white">
+<div id="loader" class="loader-wrap dark:bg-dark_table">
+    <div class="loader">
         <div></div>
         <div></div>
     </div>


### PR DESCRIPTION
**内容**
- ローダー要素に幅をもたせた
- JSの制御をload -> DOMcontentLoadedへ変更
- 読み込み順序がloadの方が遅いため
- 画面表示されたときにはローダーが動いていて、読み込みが終わればhiddenを付与する